### PR TITLE
Update for compatibility for check 0.15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    mini_portile (0.6.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.5.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   nokogiri
+
+BUNDLED WITH
+   2.2.28

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An addon to [Check](http://check.sourceforge.net/) to support C-language tests i
 
 Read the header and the example file for documentation.
 
-- Install [Ruby](https://www.ruby-lang.org/en/downloads/) and [Bundler](https://bundler.io/).
+- Install [Ruby](https://www.ruby-lang.org/en/downloads/), [Bundler](https://bundler.io/) and [Nokogiri](https://nokogiri.org/#installation).
 - Compile with `make`.
 - Install with `make install PREFIX=/usr` (defaults to `/usr/local`).
 - Use `make run-example` to run the example. Requires `make install` to be done first.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ An addon to [Check](http://check.sourceforge.net/) to support C-language tests i
 
 Read the header and the example file for documentation.
 
+- Install [Ruby](https://www.ruby-lang.org/en/downloads/) and [Bundler](https://bundler.io/).
 - Compile with `make`.
 - Install with `make install PREFIX=/usr` (defaults to `/usr/local`).
 - Use `make run-example` to run the example. Requires `make install` to be done first.

--- a/tmc-check.c
+++ b/tmc-check.c
@@ -56,7 +56,7 @@ void _tmc_register_test(Suite *s, TFun tf, const char *fname, const char *points
 {
     TCase *tc = tcase_create(fname);
     tmc_set_tcase_points(tc, fname, points);
-    _tcase_add_test(tc, tf, tname, 0, 0, 0, 1);
+    _tcase_add_test(tc, tf, fname, 0, 0, 0, 1);
     suite_add_tcase(s, tc);
 }
 #else

--- a/tmc-check.c
+++ b/tmc-check.c
@@ -51,6 +51,15 @@ void tmc_set_tcase_points(TCase *tc, const char *tc_name, const char *points)
     parse_points(points, &all_points);
 }
 
+#if CHECK_MINOR_VERSION < 15
+void _tmc_register_test(Suite *s, TFun tf, const char *fname, const char *points)
+{
+    TCase *tc = tcase_create(fname);
+    tmc_set_tcase_points(tc, fname, points);
+    _tcase_add_test(tc, tf, tname, 0, 0, 0, 1);
+    suite_add_tcase(s, tc);
+}
+#else
 void _tmc_register_test(Suite *s, const TTest *tt, const char *fname, const char *points)
 {
     TCase *tc = tcase_create(fname);
@@ -58,6 +67,7 @@ void _tmc_register_test(Suite *s, const TTest *tt, const char *fname, const char
     _tcase_add_test(tc, tt, 0, 0, 0, 1);
     suite_add_tcase(s, tc);
 }
+#endif
 
 void tmc_set_suite_points(Suite *s, const char *s_name, const char *points)
 {

--- a/tmc-check.c
+++ b/tmc-check.c
@@ -51,7 +51,7 @@ void tmc_set_tcase_points(TCase *tc, const char *tc_name, const char *points)
     parse_points(points, &all_points);
 }
 
-void _tmc_register_test(Suite *s, TTest *tt, const char *fname, const char *points)
+void _tmc_register_test(Suite *s, const TTest *tt, const char *fname, const char *points)
 {
     TCase *tc = tcase_create(fname);
     tmc_set_tcase_points(tc, fname, points);

--- a/tmc-check.c
+++ b/tmc-check.c
@@ -51,11 +51,11 @@ void tmc_set_tcase_points(TCase *tc, const char *tc_name, const char *points)
     parse_points(points, &all_points);
 }
 
-void _tmc_register_test(Suite *s, TFun tf, const char *fname, const char *points)
+void _tmc_register_test(Suite *s, TTest *tt, const char *fname, const char *points)
 {
     TCase *tc = tcase_create(fname);
     tmc_set_tcase_points(tc, fname, points);
-    _tcase_add_test(tc, tf, fname, 0, 0, 0, 1);
+    _tcase_add_test(tc, tt, 0, 0, 0, 1);
     suite_add_tcase(s, tc);
 }
 

--- a/tmc-check.h
+++ b/tmc-check.h
@@ -16,8 +16,13 @@ Suite* tmc_suite_create(const char *name, const char *points);
  *
  * One can also register the test function normally and then call tmc_set_tcase_points.
  */
+#if CHECK_MINOR_VERSION < 15
+#define tmc_register_test(suite, tf, points) _tmc_register_test((suite), (tf), "" # tf, points)
+void _tmc_register_test(Suite *s, TFun tf, const char *fname, const char *points);
+#else
 #define tmc_register_test(suite, tt, points) _tmc_register_test((suite), (tt), "" # tt, points)
 void _tmc_register_test(Suite *s, const TTest *tt, const char *fname, const char *points);
+#endif
 
 
 /**

--- a/tmc-check.h
+++ b/tmc-check.h
@@ -16,8 +16,8 @@ Suite* tmc_suite_create(const char *name, const char *points);
  *
  * One can also register the test function normally and then call tmc_set_tcase_points.
  */
-#define tmc_register_test(suite, tf, points) _tmc_register_test((suite), (tf), "" # tf, points)
-void _tmc_register_test(Suite *s, TFun tf, const char *fname, const char *points);
+#define tmc_register_test(suite, tt, points) _tmc_register_test((suite), (tt), "" # tt, points)
+void _tmc_register_test(Suite *s, TTest *tt, const char *fname, const char *points);
 
 
 /**

--- a/tmc-check.h
+++ b/tmc-check.h
@@ -17,7 +17,7 @@ Suite* tmc_suite_create(const char *name, const char *points);
  * One can also register the test function normally and then call tmc_set_tcase_points.
  */
 #define tmc_register_test(suite, tt, points) _tmc_register_test((suite), (tt), "" # tt, points)
-void _tmc_register_test(Suite *s, TTest *tt, const char *fname, const char *points);
+void _tmc_register_test(Suite *s, const TTest *tt, const char *fname, const char *points);
 
 
 /**


### PR DESCRIPTION
The latest release doesn't work with check 0.15, which is the default version in Ubuntu 21.04. I tried fixing it with this PR.

The project builds and the example works, and the [tmc-langs-rust](https://github.com/rage/tmc-langs-rust) tests that started failing after I upgraded to 21.04 work, so hopefully these changes are OK.

I had some weird Bundler issue but it went away after I deleted the lock file.